### PR TITLE
require('pull-ws/client') without including `http`

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,9 +1,8 @@
 'use strict';
-var ws = require('./')
 
 //load websocket library if we are not in the browser
 var WebSocket = require('./web-socket')
-
+var duplex = require('./duplex')
 var wsurl = require('./ws-url')
 
 function isFunction (f) {
@@ -18,7 +17,7 @@ exports.connect = function (addr, opts) {
 
   var url = wsurl(addr, location)
   var socket = new WebSocket(url)
-  stream = ws(socket, opts)
+  stream = duplex(socket, opts)
   stream.remoteAddress = url
 
   stream.close = function (cb) {
@@ -29,11 +28,3 @@ exports.connect = function (addr, opts) {
 
   return stream
 }
-
-
-
-
-
-
-
-

--- a/duplex.js
+++ b/duplex.js
@@ -1,0 +1,23 @@
+var source = require('./source')
+var sink = require('./sink')
+
+module.exports = duplex
+
+function duplex (ws, opts) {
+  var req = ws.upgradeReq || {}
+  if(opts && opts.binaryType)
+    ws.binaryType = opts.binaryType
+  else if(opts && opts.binary)
+    ws.binaryType = 'arraybuffer'
+  return {
+    source: source(ws, opts && opts.onConnect),
+    sink: sink(ws, opts),
+
+    //http properties - useful for routing or auth.
+    headers: req.headers,
+    url: req.url,
+    upgrade: req.upgrade,
+    method: req.method
+  };
+};
+

--- a/index.js
+++ b/index.js
@@ -1,25 +1,6 @@
-exports = module.exports = duplex;
+exports = module.exports = require('./duplex')
 
 exports.source = require('./source');
 exports.sink = require('./sink');
 exports.createServer = require('./server').createServer
 exports.connect = require('./client').connect
-
-function duplex (ws, opts) {
-  var req = ws.upgradeReq || {}
-  if(opts && opts.binaryType)
-    ws.binaryType = opts.binaryType
-  else if(opts && opts.binary)
-    ws.binaryType = 'arraybuffer'
-  return {
-    source: exports.source(ws, opts && opts.onConnect),
-    sink: exports.sink(ws, opts),
-
-    //http properties - useful for routing or auth.
-    headers: req.headers,
-    url: req.url,
-    upgrade: req.upgrade,
-    method: req.method
-  };
-};
-


### PR DESCRIPTION
hey cats,

this changes exports duplex in separate file, so `require('pull-ws/client')` doesn't also include `http` (and dependencies like `stream`) in the resulting browserify bundle.