### PR TITLE
Stream is undefined in the client connect callback

### DIFF
--- a/source.js
+++ b/source.js
@@ -48,7 +48,7 @@ module.exports = function(socket, cb) {
   socket.addEventListener('open', function (evt) {
     if(started || ended) return
     started = true
-    cb && cb()
+    cb && cb(null, read)
   })
 
   function read(abort, cb) {


### PR DESCRIPTION
The very first example in the readme is broken :) https://github.com/pull-stream/pull-ws#example---client
The `stream` argument to the callback in the client `connect` function is undefined.

runnable repro code: https://gist.github.com/lachenmayer/50f4d401f20941a3048d6a85104561ee

This PR simply returns the stream from the 'open' event.

This brings up the question: is this needed?
If the socket fails to open, the first read from the source stream will(/should) simply be an error.
In that case we'd just need to change the docs.
I can't think of a case where you'd need to create the stream only once connected...?

Happy to make those doc changes instead if we decide we don't want the callback.