### PR TITLE
Pass duplex stream instead of only the source stream in the client connect callback

### DIFF
--- a/client.js
+++ b/client.js
@@ -10,21 +10,27 @@ function isFunction (f) {
 }
 
 module.exports = function (addr, opts) {
-  var stream
-  if(isFunction(opts)) opts = {onConnect: opts}
+  if (isFunction(opts)) opts = {onConnect: opts}
 
   var location = typeof window === 'undefined' ? {} : window.location
 
   var url = wsurl(addr, location)
   var socket = new WebSocket(url)
-  stream = duplex(socket, opts)
-  stream.remoteAddress = url
 
+  var stream = duplex(socket, opts)
+  stream.remoteAddress = url
   stream.close = function (cb) {
-    if (cb && typeof cb == 'function')
+    if (isFunction(cb)) {
       socket.addEventListener('close', cb)
+    }
     socket.close()
   }
+
+  socket.addEventListener('open', function (e) {
+    if (opts && isFunction(opts.onConnect)) {
+      opts.onConnect(null, stream)
+    }
+  })
 
   return stream
 }

--- a/source.js
+++ b/source.js
@@ -48,7 +48,6 @@ module.exports = function(socket, cb) {
   socket.addEventListener('open', function (evt) {
     if(started || ended) return
     started = true
-    cb && cb(null, read)
   })
 
   function read(abort, cb) {


### PR DESCRIPTION
Sorry, I messed up PR #15... I didn't return the full duplex stream object.
This meant that it was possible to read from the stream but not write to it (doh).

This caused 2 of the tests to fail (`test/pass-in-server.js` & `test/server-echo.js`).
This PR fixes these test failures.