### PR TITLE
feat: expose .address from underlying server

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,6 +59,8 @@ module.exports = function (opts, onConnection) {
     wsServer.close()
     return emitter
   }
+
+  emitter.address = server.address.bind(server)
   return emitter
 }
 

--- a/test/server-address.js
+++ b/test/server-address.js
@@ -1,0 +1,17 @@
+var WS = require('../')
+var tape = require('tape')
+
+tape('server .address should return bound address', function (t) {
+  var server = WS.createServer().listen(55214, function () {
+    t.equal(typeof server.address, 'function')
+    t.deepEqual(
+      server.address(),
+      {address: '::', family: 'IPv6', port: 55214},
+      'return address should match'
+    )
+
+    server.close(function () {
+      t.end()
+    })
+  })
+})

--- a/test/server-address.js
+++ b/test/server-address.js
@@ -4,12 +4,7 @@ var tape = require('tape')
 tape('server .address should return bound address', function (t) {
   var server = WS.createServer().listen(55214, function () {
     t.equal(typeof server.address, 'function')
-    t.deepEqual(
-      server.address(),
-      {address: '::', family: 'IPv6', port: 55214},
-      'return address should match'
-    )
-
+    t.equal(server.address().port, 55214, 'return address should match')
     server.close(function () {
       t.end()
     })


### PR DESCRIPTION
Currently there is not way of telling what is the resolved address after the server has been created. Exposing `.address` from the underlying server should allow for this, which is handy for `0` ports.