### PR TITLE
Upgrade Node module dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/duplex.js
+++ b/duplex.js
@@ -19,5 +19,5 @@ function duplex (ws, opts) {
     upgrade: req.upgrade,
     method: req.method
   };
-};
+}
 

--- a/package.json
+++ b/package.json
@@ -26,16 +26,14 @@
   "dependencies": {
     "relative-url": "^1.0.2",
     "safe-buffer": "^5.1.1",
-    "ws": "^1.1.0"
+    "ws": "^7.1.2"
   },
   "devDependencies": {
     "mapleTree": "^0.5.1",
     "pull-goodbye": "~0.0.1",
-    "pull-json-doubleline": "^1.0.0",
-    "pull-split": "^0.2.0",
+    "pull-json-doubleline": "^2.0.0",
     "pull-stream": "^3.3.2",
-    "pull-through": "^1.0.18",
-    "tap": "^5.7.2",
+    "tap": "^14.6.4",
     "tape": "^4.4.0",
     "testling": "^1.7.1",
     "wsurl": "^1.0.0"

--- a/server.js
+++ b/server.js
@@ -38,9 +38,9 @@ module.exports = !WebSocket.Server ? null : function (opts, onConnection) {
     proxy(server, 'request')
     proxy(server, 'close')
 
-    wsServer.on('connection', function (socket) {
+    wsServer.on('connection', function (socket, req) {
       var stream = ws(socket)
-      stream.remoteAddress = socket.upgradeReq.socket.remoteAddress
+      stream.remoteAddress = req.socket.remoteAddress
       emitter.emit('connection', stream)
     })
 

--- a/server.js
+++ b/server.js
@@ -1,13 +1,11 @@
 var ws = require('./')
 var WebSocket = require('ws')
-var url = require('url')
 var http = require('http')
 var https = require('https')
 
 var EventEmitter = require('events').EventEmitter
 module.exports = !WebSocket.Server ? null : function (opts, onConnection) {
     var emitter = new EventEmitter()
-    var server
     if (typeof opts === 'function'){
       onConnection = opts
       opts = null

--- a/source.js
+++ b/source.js
@@ -80,7 +80,7 @@ module.exports = function(socket, cb) {
     else
       receiver = cb;
 
-  };
+  }
 
   return read;
 };

--- a/test/error.js
+++ b/test/error.js
@@ -14,7 +14,7 @@ test('test error', function (t) {
     pull.values(['x', 'y', 'z']),
     pull.through(null, function (err) {
       if(_err) {
-        t.strictEqual(err, _err);
+        t.strictEqual(err.error, _err.error);
         t.end();
       }
       _err = err

--- a/test/error.js
+++ b/test/error.js
@@ -1,6 +1,5 @@
 var test = require('tape');
 var WebSocket = require('ws');
-var endpoint = require('./helpers/wsurl') + '/read';
 var pull = require('pull-stream');
 var ws = require('../');
 
@@ -34,14 +33,11 @@ test('test error', function (t) {
 //connect to a server that does not exist, and check that it errors.
 //should pass the error to both sides of the stream.
 test('test error', function (t) {
-  var _err
-
   ws(new WebSocket('ws://localhost:34897/' + Math.random()),
     {onConnect: function (err) {
       t.ok(err)
       t.end()
     }})
-
 })
 
 

--- a/test/server.js
+++ b/test/server.js
@@ -27,8 +27,8 @@ var wss = new WebSocketServer({ port: port });
     });
   });
 
-  wss.on('connection', function(ws) {
-    var match = router.match(ws.upgradeReq.url);
+  wss.on('connection', function(ws, req) {
+    var match = router.match(req.url);
     if (match && typeof match.fn == 'function') {
       match.fn(ws);
     }

--- a/test/ws-url.js
+++ b/test/ws-url.js
@@ -24,11 +24,6 @@ tape('map from a relative url to one for this domain', function (t) {
 })
 
 tape('same path works on dev and deployed', function (t) {
-  var location = {
-    protocol: 'http',
-    host: 'localhost:8000',
-  }
-
   t.equal(
     wsurl('/', {
       protocol: 'http',


### PR DESCRIPTION
I noticed a security advisory regarding the `ws` module coming from this repo, so I went through and ensured that all of the npm dependencies were 100% up-to-date. It looks like the incompatibilities were caused by `upgradeReq` being removed, but [the solution](https://github.com/websockets/ws/pull/1099#issuecomment-300691583) was pretty simple.