### PR TITLE
add conversion of Blob to Buffer for browsers

### DIFF
--- a/source.js
+++ b/source.js
@@ -21,10 +21,14 @@ module.exports = function(socket, cb) {
   var receiver;
   var ended;
   var started = false;
-  socket.addEventListener('message', function(evt) {
+  socket.addEventListener('message', async function(evt) {
     var data = evt.data;
     if (isArrayBuffer(data)) {
       data = Buffer.from(data);
+    }
+    
+    if (typeof Blob !== 'undefined' && data instanceof Blob) {
+      data = Buffer.from(await data.arrayBuffer())
     }
 
     if (receiver) {


### PR DESCRIPTION
This PR fixes #30 by adding a check and conversion in browsers when data is of type [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)

I do not like that it required converting the enclosing function to `async`, but converting a `Blob` to and `arrayBuffer` is async, so open to better solutions.